### PR TITLE
`commit-msg` git hook

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.3']
+        ruby-version: ['2.7', '3.2']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,38 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.3']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+source "https://rubygems.org"

--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,4 @@
 source "https://rubygems.org"
+
+gem "rake"
+gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    minitest (5.22.3)
+    rake (13.1.0)
+
+PLATFORMS
+  x86_64-darwin-21
+
+DEPENDENCIES
+  minitest
+  rake
+
+BUNDLED WITH
+   2.3.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   minitest

--- a/Rakefile
+++ b/Rakefile
@@ -8,8 +8,10 @@ Rake::TestTask.new do |task|
   task.options = "--pride"
 end
 
-desc "Generate the commit-msg hook and verify its syntax"
-file "generate-hook" do
-  sh "erb githooks/commit-msg.TEMPLATE.erb > githooks/commit-msg"
+file "githooks/commit-msg" do
+  sh "erb githooks/commit-msg.TEMPLATE.erb > githooks/commit-msg && chmod +x githooks/commit-msg"
   ruby "-c githooks/commit-msg"
 end
+
+desc "Generate the commit-msg hook and verify its syntax"
+task generate_hook: %w[githooks/commit-msg]

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,9 @@ Rake::TestTask.new do |task|
   task.test_files = FileList["scripts/tests/*_test.rb"]
   task.options = "--pride"
 end
+
+desc "Generate the commit-msg hook and verify its syntax"
+file "generate-hook" do
+  sh "erb githooks/commit-msg.TEMPLATE.erb > githooks/commit-msg"
+  ruby "-c githooks/commit-msg"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require "rake/testtask"
+
+task default: "test"
+
+Rake::TestTask.new do |task|
+  task.libs = ["scripts/tests"]
+  task.test_files = FileList["scripts/tests/*_test.rb"]
+  task.options = "--pride"
+end

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,0 +1,39 @@
+# Automated Pairing Messages with Git Hooks
+
+Use this `commit-msg` git hook to automatically share credit with your collaborators on a commit, without needing to manually paste strings into your commit message.
+
+Instead, credit them in natural language within the context of your commit message. For example:
+
+```
+Add new features. Pairing with @mona.
+```
+
+On a system with `gh` and the `gh-pairing-with` extension installed, and in a repository with the `commit-msg` hook enabled, the above commit message will be automatically rewritten to include the appropriate `Co-authored-by:` string.
+
+See examples of supported language in [`scripts/tests/commit_msg_pairs_test.rb`](../scripts/tests/commit_msg_pairs_test.rb). Pull requests welcome!
+
+## What is a Git Hook?
+
+Git Hooks are scripts that are [run automatically when certain actions are taken](https://git-scm.com/docs/githooks) in a git repository. They are not transferred automatically when a repository is cloned, so setting them up requires affirmative action on the user's part.
+
+To be run by git, a git hook must have its executable bit set (e.g. `chmod +x commit-msg`).
+
+You have two options for installing git hooks in your development environment, though they are mutually-exclusive:
+
+1. Adding individual scripts to the `.git/hooks` directory of a given repository.
+2. Configuring the `hooksPath` option in your local `.gitconfig` file. This will set a given directory on your system as the overriding path for git hooks in every repository that you interact with. Setting `hooksPath` in your config will cause git to ignore any hooks defined in the repository's `.git/hooks` directory.
+
+Each script must be named to match the name of the action on which occasion it will run.
+
+## Installation
+
+Copy the `commit-msg` script in this directory to the `.git/hooks` directory in the repository where you'd like to use it. Alternately, create a directory (e.g. `~/githooks`), move the `commit-msg` script there, and add the following to your `.gitconfig`:
+
+```
+[core]
+	hooksPath = ~/githooks
+```
+
+### Prerequisites
+This script won't work as written without an existing installation of `gh` and the `gh-pairing-with` extension. See [README.md](../README.md#installation) for installation instructions.
+

--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+def parse_pairing_handles(commit_msg)
+  descriptors = [
+    "pairing with",
+    "collaborating with",
+    "working with"
+  ]
+
+  regex = /(?:#{descriptors.join("|")}):? (@[^.\r\n]*)/i
+  match = commit_msg.scan(regex)
+
+  return [] unless match
+
+  pairs = []
+  match.flatten.each do |substring|
+    substring.split do |word|
+      next unless word.start_with?("@")
+      word.gsub!(/^@/, "")
+      word.gsub!(/[,;.!?]$/i, "")
+      pairs << word unless pairs.include?(word)
+    end
+  end
+
+  pairs
+end
+
+
+# Cross-platform way of finding an executable in the $PATH.
+# https://stackoverflow.com/a/5471032 (thx mislav)
+#   which('ruby') #=> /usr/bin/ruby
+def which(cmd)
+  exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+  ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+    exts.each do |ext|
+      exe = File.join(path, "#{cmd}#{ext}")
+      return exe if File.executable?(exe) && !File.directory?(exe)
+    end
+  end
+  nil
+end
+
+message_file = ARGV[0]
+message = File.read(message_file)
+
+handles = parse_pairing_handles(message)
+
+exit 0 if handles.empty?
+
+gh_installed = which("gh")
+
+if !gh_installed
+  puts "GitHub CLI is not installed."
+  exit 0
+end
+
+pairing_with_extension_installed = `gh extensions list | grep pairing-with`.length > 0
+
+if !pairing_with_extension_installed
+  puts "The pairing-with extension for GitHub CLI is not installed."
+  exit 0
+end
+
+coauthored_by_strings = []
+
+handles.each do |handle|
+  coauthored_by_strings << `gh pairing-with #{handle}`.strip
+end
+
+File.write(message_file, "\n#{coauthored_by_strings.join("\n")}", mode: "a+")

--- a/githooks/commit-msg.TEMPLATE.erb
+++ b/githooks/commit-msg.TEMPLATE.erb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+<%= File.read(File.expand_path("scripts/commit_msg_pairs.rb")) %>
+
+# Cross-platform way of finding an executable in the $PATH.
+# https://stackoverflow.com/a/5471032 (thx mislav)
+#   which('ruby') #=> /usr/bin/ruby
+def which(cmd)
+  exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+  ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+    exts.each do |ext|
+      exe = File.join(path, "#{cmd}#{ext}")
+      return exe if File.executable?(exe) && !File.directory?(exe)
+    end
+  end
+  nil
+end
+
+message_file = ARGV[0]
+message = File.read(message_file)
+
+handles = parse_pairing_handles(message)
+
+exit 0 if handles.empty?
+
+gh_installed = which("gh")
+
+if !gh_installed
+  puts "GitHub CLI is not installed."
+  exit 0
+end
+
+pairing_with_extension_installed = `gh extensions list | grep pairing-with`.length > 0
+
+if !pairing_with_extension_installed
+  puts "The pairing-with extension for GitHub CLI is not installed."
+  exit 0
+end
+
+coauthored_by_strings = []
+
+handles.each do |handle|
+  coauthored_by_strings << `gh pairing-with #{handle}`.strip
+end
+
+File.write(message_file, "\n#{coauthored_by_strings.join("\n")}", mode: "a+")

--- a/scripts/commit_msg_pairs.rb
+++ b/scripts/commit_msg_pairs.rb
@@ -13,6 +13,7 @@ def parse_pairing_handles(commit_msg)
   match.flatten.each do |substring|
     substring.split do |word|
       next unless word.start_with?("@")
+      word.gsub!(/^@/, "")
       word.gsub!(/[,;.]$/i, "")
       pairs << word unless pairs.include?(word)
     end

--- a/scripts/commit_msg_pairs.rb
+++ b/scripts/commit_msg_pairs.rb
@@ -14,7 +14,7 @@ def parse_pairing_handles(commit_msg)
     substring.split do |word|
       next unless word.start_with?("@")
       word.gsub!(/^@/, "")
-      word.gsub!(/[,;.]$/i, "")
+      word.gsub!(/[,;.!?]$/i, "")
       pairs << word unless pairs.include?(word)
     end
   end

--- a/scripts/commit_msg_pairs.rb
+++ b/scripts/commit_msg_pairs.rb
@@ -1,0 +1,22 @@
+def parse_pairing_handles(commit_msg)
+  # Valid pairing formats
+  # * pairing with @username
+  # * Pairing with @username, @username2, and @username3
+  # * pairing with @username and @username2
+
+  regex = /pairing with (@[^.\r\n]*)/i
+  match = commit_msg.scan(regex)
+
+  return [] unless match
+
+  pairs = []
+  match.flatten.each do |substring|
+    substring.split do |word|
+      next unless word.start_with?("@")
+      word.gsub!(/[,;.]$/i, "")
+      pairs << word unless pairs.include?(word)
+    end
+  end
+
+  pairs
+end

--- a/scripts/commit_msg_pairs.rb
+++ b/scripts/commit_msg_pairs.rb
@@ -1,10 +1,11 @@
 def parse_pairing_handles(commit_msg)
-  # Valid pairing formats
-  # * pairing with @username
-  # * Pairing with @username, @username2, and @username3
-  # * pairing with @username and @username2
+  descriptors = [
+    "pairing with",
+    "collaborating with",
+    "working with"
+  ]
 
-  regex = /pairing with (@[^.\r\n]*)/i
+  regex = /(?:#{descriptors.join("|")}):? (@[^.\r\n]*)/i
   match = commit_msg.scan(regex)
 
   return [] unless match

--- a/scripts/tests/commit_msg_pairs_test.rb
+++ b/scripts/tests/commit_msg_pairs_test.rb
@@ -4,7 +4,7 @@ require_relative "../commit_msg_pairs"
 class PairingTest < MiniTest::Test
   def test_nobody_pairing
     message = "This is a regular commit message"
-    assert_empty parse_pairing_handles(message)
+    assert_pairs [], message
   end
 
   def test_one_pair
@@ -14,8 +14,7 @@ class PairingTest < MiniTest::Test
     Pairing with @eeyore.
     MSG
 
-    assert_equal 1, parse_pairing_handles(message).length
-    assert_equal ["eeyore"], parse_pairing_handles(message)
+    assert_pairs ["eeyore"], message
   end
 
   def test_two_pairs_on_two_lines
@@ -25,8 +24,8 @@ class PairingTest < MiniTest::Test
     Pairing with @pooh.
     Pairing with @tigger.
     MSG
-    assert_equal 2, parse_pairing_handles(message).length
-    assert_equal ["pooh", "tigger"], parse_pairing_handles(message)
+
+    assert_pairs ["pooh", "tigger"], message
   end
 
   def test_many_pairs_on_one_line
@@ -36,8 +35,7 @@ class PairingTest < MiniTest::Test
     @eeyore didn't help at all.
     MSG
 
-    assert_equal 3, parse_pairing_handles(message).length
-    assert_equal ["pooh", "tigger", "piglet"], parse_pairing_handles(message)
+    assert_pairs ["pooh", "tigger", "piglet"], message
   end
 
   def test_when_you_are_really_excited
@@ -45,8 +43,7 @@ class PairingTest < MiniTest::Test
     It finally worked! Pairing with @christoph3rr0bin!
     MSG
 
-    assert_equal 1, parse_pairing_handles(message).length
-    assert_equal ["christoph3rr0bin"], parse_pairing_handles(message)
+    assert_pairs ["christoph3rr0bin"], message
   end
 
   def test_when_you_are_not_sure_what_just_happened
@@ -54,7 +51,39 @@ class PairingTest < MiniTest::Test
     Is this it? Pairing with @roo?
     MSG
 
-    assert_equal 1, parse_pairing_handles(message).length
-    assert_equal ["roo"], parse_pairing_handles(message)
+    assert_pairs ["roo"], message
+  end
+
+  def test_no_punctuation
+    message = <<-MSG
+    fixed it. pairing with @owl
+    MSG
+
+    assert_pairs ["owl"], message
+  end
+
+  def test_with_a_colon
+    message = <<-MSG
+    fixed it. pairing with: @owl, @roo, @eeyore
+    MSG
+
+    assert_pairs ["owl", "roo", "eeyore"], message
+  end
+
+  def test_other_wordings
+    wordings = ["collaborating with", "working with"]
+    wordings.each do |wording|
+      message = <<-MSG
+      fixed! #{wording} @owl.
+      MSG
+
+      assert_pairs ["owl"], message
+    end
+  end
+
+  def assert_pairs(expected_pairs, message)
+    result = parse_pairing_handles(message)
+    assert_equal expected_pairs.length, result.length
+    assert_equal expected_pairs, result
   end
 end

--- a/scripts/tests/commit_msg_pairs_test.rb
+++ b/scripts/tests/commit_msg_pairs_test.rb
@@ -1,0 +1,42 @@
+require "minitest/autorun"
+require "../commit_msg_pairs"
+
+class PairingTest < MiniTest::Test
+  def test_nobody_pairing
+    message = "This is a regular commit message"
+    assert_empty parse_pairing_handles(message)
+  end
+
+  def test_one_pair
+    message = <<-MSG
+    Does some stuff.
+
+    Pairing with @eeyore.
+    MSG
+
+    assert_equal 1, parse_pairing_handles(message).length
+    assert_equal ["@eeyore"], parse_pairing_handles(message)
+  end
+
+  def test_two_pairs_on_two_lines
+    message = <<-MSG
+    Exciting new functionality.
+
+    Pairing with @pooh.
+    Pairing with @tigger.
+    MSG
+    assert_equal 2, parse_pairing_handles(message).length
+    assert_equal ["@pooh", "@tigger"], parse_pairing_handles(message)
+  end
+
+  def test_many_pairs_on_one_line
+    message = <<-MSG
+    We did it! Pairing with @pooh, @tigger, and @piglet.
+
+    @eeyore didn't help at all.
+    MSG
+
+    assert_equal 3, parse_pairing_handles(message).length
+    assert_equal ["@pooh", "@tigger", "@piglet"], parse_pairing_handles(message)
+  end
+end

--- a/scripts/tests/commit_msg_pairs_test.rb
+++ b/scripts/tests/commit_msg_pairs_test.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require "../commit_msg_pairs"
+require_relative "../commit_msg_pairs"
 
 class PairingTest < MiniTest::Test
   def test_nobody_pairing
@@ -15,7 +15,7 @@ class PairingTest < MiniTest::Test
     MSG
 
     assert_equal 1, parse_pairing_handles(message).length
-    assert_equal ["@eeyore"], parse_pairing_handles(message)
+    assert_equal ["eeyore"], parse_pairing_handles(message)
   end
 
   def test_two_pairs_on_two_lines
@@ -26,7 +26,7 @@ class PairingTest < MiniTest::Test
     Pairing with @tigger.
     MSG
     assert_equal 2, parse_pairing_handles(message).length
-    assert_equal ["@pooh", "@tigger"], parse_pairing_handles(message)
+    assert_equal ["pooh", "tigger"], parse_pairing_handles(message)
   end
 
   def test_many_pairs_on_one_line
@@ -37,6 +37,6 @@ class PairingTest < MiniTest::Test
     MSG
 
     assert_equal 3, parse_pairing_handles(message).length
-    assert_equal ["@pooh", "@tigger", "@piglet"], parse_pairing_handles(message)
+    assert_equal ["pooh", "tigger", "piglet"], parse_pairing_handles(message)
   end
 end

--- a/scripts/tests/commit_msg_pairs_test.rb
+++ b/scripts/tests/commit_msg_pairs_test.rb
@@ -1,7 +1,7 @@
 require "minitest/autorun"
 require_relative "../commit_msg_pairs"
 
-class PairingTest < MiniTest::Test
+class PairingTest < Minitest::Test
   def test_nobody_pairing
     message = "This is a regular commit message"
     assert_pairs [], message

--- a/scripts/tests/commit_msg_pairs_test.rb
+++ b/scripts/tests/commit_msg_pairs_test.rb
@@ -39,4 +39,22 @@ class PairingTest < MiniTest::Test
     assert_equal 3, parse_pairing_handles(message).length
     assert_equal ["pooh", "tigger", "piglet"], parse_pairing_handles(message)
   end
+
+  def test_when_you_are_really_excited
+    message = <<-MSG
+    It finally worked! Pairing with @christoph3rr0bin!
+    MSG
+
+    assert_equal 1, parse_pairing_handles(message).length
+    assert_equal ["christoph3rr0bin"], parse_pairing_handles(message)
+  end
+
+  def test_when_you_are_not_sure_what_just_happened
+    message = <<-MSG
+    Is this it? Pairing with @roo?
+    MSG
+
+    assert_equal 1, parse_pairing_handles(message).length
+    assert_equal ["roo"], parse_pairing_handles(message)
+  end
 end


### PR DESCRIPTION
Support for parsing a commit message that includes natural language like "Pairing with @mona" with a `commit-msg` hook. Automatically append the correct `Co-authored-by:` string (sourced from `gh pairing-with`) to the commit message.

Also adds:
* CI for the Ruby method that parses the commit message
* Scripted generation of the hook (so future updates to the parsing don't require copy/paste)