### PR TITLE
Provide helpful error if type assertion fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,11 @@ func cli() error {
 		return fmt.Errorf("could not unmarshal: %w", err)
 	}
 
-	data := graphqlResponse["data"].(map[string]interface{})
+	data, ok := graphqlResponse["data"].(map[string]interface{})
+
+	if !ok {
+		return fmt.Errorf("could not parse response.\n\nyou may need to add the appropriate scopes to your token.\ntry running the following:\n\tgh auth refresh --scopes user:email,read:user")
+	}
 
 	for _, user := range data {
 		if user == nil {


### PR DESCRIPTION
It's entirely possible that type assertion could fail for other reasons, but the only one we've seen so far is that a user's token doesn't have the right scopes.

This adds a troubleshooting step in the event of such a failure that previously only lived in the readme.

Fix #4.