### PR TITLE
Use X-OAuth-Scopes response header to determine missing scopes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/cli/go-gh/v2 v2.9.0
+	github.com/deckarep/golang-set/v2 v2.6.0
 	github.com/mergestat/fluentgraphql v0.0.0-20220506205554-9162f392519f
 	github.com/stretchr/testify v1.7.0
 )
@@ -11,7 +12,6 @@ require (
 require (
 	github.com/cli/safeexec v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/graphql-go/graphql v0.8.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 require (
 	github.com/cli/safeexec v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/graphql-go/graphql v0.8.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=
+github.com/deckarep/golang-set/v2 v2.6.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
 github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -73,4 +74,22 @@ func TestCoAuthoredByWithEmailAndName(t *testing.T) {
 
 	expectedCoAuthoredBy := "Co-authored-by: Miss Mona Lisa Octocat <monalisa@github.com>\n"
 	assert.Equal(t, expectedCoAuthoredBy, user.coAuthoredBy())
+}
+
+func TestMissingScopes(t *testing.T) {
+	scopesHeader := ""
+	expectedMissingScopes := mapset.NewSet("user:email", "read:user")
+	assert.Equal(t, expectedMissingScopes, missingTokenScopes(scopesHeader))
+}
+
+func TestMissingScopesWithAllScopes(t *testing.T) {
+	scopesHeader := " codespace, gist, read:org, read:user, repo, user:email, workflow "
+	expectedMissingScopes := mapset.NewSet[string]()
+	assert.Equal(t, expectedMissingScopes, missingTokenScopes(scopesHeader))
+}
+
+func TestMissingScopesMissingOneScope(t *testing.T) {
+	scopesHeader := " codespace, gist, read:org, repo, user:email, workflow "
+	expectedMissingScopes := mapset.NewSet("read:user")
+	assert.Equal(t, expectedMissingScopes, missingTokenScopes(scopesHeader))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -82,6 +82,12 @@ func TestMissingScopes(t *testing.T) {
 	assert.Equal(t, expectedMissingScopes, missingTokenScopes(scopesHeader))
 }
 
+func TestMissingScopesOnlyWhitespace(t *testing.T) {
+	scopesHeader := "      "
+	expectedMissingScopes := mapset.NewSet("user:email", "read:user")
+	assert.Equal(t, expectedMissingScopes, missingTokenScopes(scopesHeader))
+}
+
 func TestMissingScopesWithAllScopes(t *testing.T) {
 	scopesHeader := " codespace, gist, read:org, read:user, repo, user:email, workflow "
 	expectedMissingScopes := mapset.NewSet[string]()


### PR DESCRIPTION
Fix https://github.com/schustafa/gh-pairing-with/issues/6

A GitHub API response includes [an `X-OAuth-Scopes` header](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps) that we can use to determine if a user is getting an error due to the lack of required scopes.

This change improves on the approach in #4 by checking that header in the event of a parse failure. This allows us to give more certain troubleshooting advice in that case (and makes it less likely that we'll give advice that won't fix the problem).