### PR TITLE
Add `--alias` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ Co-authored-by: Monalisa Octocat <92997159+mona@users.noreply.github.com>
 Co-authored-by: AJ Schuster <126731+schustafa@users.noreply.github.com>
 ```
 
+## Aliases
+
+Do you regularly work with more than one collaborator at a time? Or do you work with a collaborator with a hard-to-type or hard-to-remember username? Create an alias!
+
+```bash
+> gh pairing-with --alias buddies schustafa mona
+
+> gh pairing-with buddies
+Co-authored-by: Monalisa Octocat <92997159+mona@users.noreply.github.com>
+Co-authored-by: AJ Schuster <126731+schustafa@users.noreply.github.com>
+```
+
+Any aliases you pass will be expanded alongside other handles as well:
+
+```bash
+> gh pairing-with buddies abigailychen
+Co-authored-by: Monalisa Octocat <92997159+mona@users.noreply.github.com>
+Co-authored-by: AJ Schuster <126731+schustafa@users.noreply.github.com>
+Co-authored-by: Abigail Chen <6415144+abigailychen@users.noreply.github.com>
+```
+
+N.B. Your aliases have a higher priority than “actual” handles, so don’t create an alias with the name of an actual user you collaborate with.
+
 ## Troubleshooting
 
 ### Scopes

--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,10 @@ func (c *Config) ExpandHandles(handles []string) []string {
 	return expandedHandles
 }
 
+func (c *Config) GetAllAliases() map[string][]string {
+	return c.Aliases
+}
+
 func createConfigFileIfMissing(configFilePath string) error {
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
 		newConfigFile, err := os.OpenFile(

--- a/config/config.go
+++ b/config/config.go
@@ -24,25 +24,9 @@ func (c *Config) AddAliasForHandles(alias string, handles []string) error {
 
 	c.Aliases[alias] = handles
 
-	configFilePath, err := getConfigFilePath()
+	err := c.persist()
 	if err != nil {
-		return err
-	}
-
-	updatedFile, err := yaml.Marshal(c)
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Create(configFilePath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	_, err = io.Writer.Write(f, updatedFile)
-	if err != nil {
-		return fmt.Errorf("could not write to config file: %w", err)
+		return fmt.Errorf("error persisting config: %w", err)
 	}
 
 	return nil
@@ -72,6 +56,19 @@ func (c *Config) AliasExists(alias string) bool {
 func (c *Config) DeleteAlias(alias string) error {
 	delete(c.Aliases, alias)
 
+	err := c.persist()
+	if err != nil {
+		return fmt.Errorf("error persisting config: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Config) GetAllAliases() map[string][]string {
+	return c.Aliases
+}
+
+func (c *Config) persist() error {
 	configFilePath, err := getConfigFilePath()
 	if err != nil {
 		return err
@@ -90,14 +87,10 @@ func (c *Config) DeleteAlias(alias string) error {
 
 	_, err = io.Writer.Write(f, updatedFile)
 	if err != nil {
-		return fmt.Errorf("could not write to config file: %w", err)
+		return err
 	}
 
 	return nil
-}
-
-func (c *Config) GetAllAliases() map[string][]string {
-	return c.Aliases
 }
 
 func getDefaultConfig() Config {

--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,38 @@ func (c *Config) ExpandHandles(handles []string) []string {
 	return slices.Compact(expandedHandles)
 }
 
+func (c *Config) AliasExists(alias string) bool {
+	_, ok := c.Aliases[alias]
+	return ok
+}
+
+func (c *Config) DeleteAlias(alias string) error {
+	delete(c.Aliases, alias)
+
+	configFilePath, err := getConfigFilePath()
+	if err != nil {
+		return err
+	}
+
+	updatedFile, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(configFilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Writer.Write(f, updatedFile)
+	if err != nil {
+		return fmt.Errorf("could not write to config file: %w", err)
+	}
+
+	return nil
+}
+
 func (c *Config) GetAllAliases() map[string][]string {
 	return c.Aliases
 }

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -58,7 +59,9 @@ func (c *Config) ExpandHandles(handles []string) []string {
 		}
 	}
 
-	return expandedHandles
+	slices.Sort(expandedHandles)
+
+	return slices.Compact(expandedHandles)
 }
 
 func (c *Config) GetAllAliases() map[string][]string {

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,33 @@ type Config struct {
 	Aliases map[string][]string
 }
 
+func (c *Config) AddAliasForHandles(alias string, handles []string) error {
+	c.Aliases[alias] = handles
+
+	configFilePath, err := getConfigFilePath()
+	if err != nil {
+		return err
+	}
+
+	updatedFile, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(configFilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Writer.Write(f, updatedFile)
+	if err != nil {
+		return fmt.Errorf("could not write to config file: %w", err)
+	}
+
+	return nil
+}
+
 func createConfigFileIfMissing(configFilePath string) error {
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
 		newConfigFile, err := os.OpenFile(
@@ -94,29 +121,4 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return &config, nil
-}
-
-func (c *Config) Save() error {
-	configFilePath, err := getConfigFilePath()
-	if err != nil {
-		return err
-	}
-
-	updatedFile, err := yaml.Marshal(c)
-	if err != nil {
-		return err
-	}
-
-	f, err := os.Create(configFilePath)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	_, err = io.Writer.Write(f, updatedFile)
-	if err != nil {
-		return fmt.Errorf("could not write to config file: %w", err)
-	}
-
-	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Aliases map[string][]string
+}
+
+func createConfigFileIfMissing(configFilePath string) error {
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		newConfigFile, err := os.OpenFile(
+			configFilePath,
+			os.O_RDWR|os.O_CREATE|os.O_EXCL,
+			0666,
+		)
+		if err != nil {
+			return err
+		}
+
+		var emptyConfig Config
+		emptyConfig.Aliases = make(map[string][]string)
+
+		blankConfigFile, err := yaml.Marshal(emptyConfig)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Writer.Write(newConfigFile, blankConfigFile)
+		if err != nil {
+			return err
+		}
+
+		defer newConfigFile.Close()
+		return nil
+	}
+
+	return nil
+}
+
+func getConfigFilePath() (string, error) {
+	const PairingWithDir = "gh-pairing-with"
+	const ConfigYmlFileName = "config.yml"
+	const DEFAULT_XDG_CONFIG_DIRNAME = ".config"
+
+	configDir := os.Getenv("XDG_CONFIG_HOME")
+
+	if configDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		configDir = filepath.Join(homeDir, DEFAULT_XDG_CONFIG_DIRNAME)
+	}
+
+	pairingWithConfigDir := filepath.Join(configDir, PairingWithDir)
+	return filepath.Join(pairingWithConfigDir, ConfigYmlFileName), nil
+}
+
+func LoadConfig() (*Config, error) {
+	var config Config
+
+	configFilePath, err := getConfigFilePath()
+
+	if err != nil {
+		return nil, err
+	}
+
+	configDir := filepath.Dir(configFilePath)
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(configDir, os.ModePerm); err != nil {
+			return &config, err
+		}
+	}
+
+	if err := createConfigFileIfMissing(configFilePath); err != nil {
+		return &config, err
+	}
+
+	existingFile, err := os.ReadFile(configFilePath)
+	if err != nil {
+		return &config, err
+	}
+
+	err = yaml.Unmarshal(existingFile, &config)
+	if err != nil {
+		return &config, err
+	}
+
+	return &config, nil
+}
+
+func (c *Config) Save() error {
+	configFilePath, err := getConfigFilePath()
+	if err != nil {
+		return err
+	}
+
+	updatedFile, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(configFilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Writer.Write(f, updatedFile)
+	if err != nil {
+		return fmt.Errorf("could not write to config file: %w", err)
+	}
+
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,13 @@ type Config struct {
 }
 
 func (c *Config) AddAliasForHandles(alias string, handles []string) error {
+	// if handles includes the alias literal, return an error
+	for _, handle := range handles {
+		if handle == alias {
+			return fmt.Errorf("an alias cannot reference itself")
+		}
+	}
+
 	c.Aliases[alias] = handles
 
 	configFilePath, err := getConfigFilePath()
@@ -38,6 +45,20 @@ func (c *Config) AddAliasForHandles(alias string, handles []string) error {
 	}
 
 	return nil
+}
+
+func (c *Config) ExpandHandles(handles []string) []string {
+	var expandedHandles []string
+
+	for _, handle := range handles {
+		if alias, ok := c.Aliases[handle]; ok {
+			expandedHandles = append(expandedHandles, alias...)
+		} else {
+			expandedHandles = append(expandedHandles, handle)
+		}
+	}
+
+	return expandedHandles
 }
 
 func createConfigFileIfMissing(configFilePath string) error {

--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,12 @@ func (c *Config) GetAllAliases() map[string][]string {
 	return c.Aliases
 }
 
+func getDefaultConfig() Config {
+	return Config{
+		Aliases: make(map[string][]string),
+	}
+}
+
 func createConfigFileIfMissing(configFilePath string) error {
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
 		newConfigFile, err := os.OpenFile(
@@ -76,10 +82,7 @@ func createConfigFileIfMissing(configFilePath string) error {
 			return err
 		}
 
-		var emptyConfig Config
-		emptyConfig.Aliases = make(map[string][]string)
-
-		blankConfigFile, err := yaml.Marshal(emptyConfig)
+		blankConfigFile, err := yaml.Marshal(getDefaultConfig())
 		if err != nil {
 			return err
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDefaultConfig(t *testing.T) {
+	expectedConfig := Config{
+		Aliases: make(map[string][]string),
+	}
+
+	defaultConfig := getDefaultConfig()
+
+	assert.NotNil(t, defaultConfig)
+	assert.ElementsMatch(t, expectedConfig.Aliases, defaultConfig.Aliases)
+}
+
+func TestGetConfigFilePath(t *testing.T) {
+	expectedDir := "/tmp/test-config"
+	t.Setenv("XDG_CONFIG_HOME", expectedDir)
+	expectedPath := filepath.Join(expectedDir, "gh-pairing-with", "config.yml")
+
+	configFilePath, err := getConfigFilePath()
+	assert.Nil(t, err)
+	assert.Equal(t, expectedPath, configFilePath)
+
+	// Test when XDG_CONFIG_HOME is not set
+	t.Setenv("XDG_CONFIG_HOME", "")
+	homeDir, err := os.UserHomeDir()
+	assert.Nil(t, err)
+
+	expectedPath = filepath.Join(homeDir, ".config", "gh-pairing-with", "config.yml")
+	configFilePath, err = getConfigFilePath()
+	assert.Nil(t, err)
+	assert.Equal(t, expectedPath, configFilePath)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,51 @@ func TestGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, expectedConfig.Aliases, defaultConfig.Aliases)
 }
 
+func TestGetAllAliases(t *testing.T) {
+	config := Config{
+		Aliases: map[string][]string{
+			"alias1": {"user1", "user2"},
+			"alias2": {"user3", "user4"},
+			"alias3": {"user5", "user6"},
+		},
+	}
+
+	assert.Equal(t,
+		config.Aliases,
+		config.GetAllAliases(),
+	)
+}
+
+func TestExpandHandles(t *testing.T) {
+	config := Config{
+		Aliases: map[string][]string{
+			"alias1": {"user1", "user2"},
+			"alias2": {"user3", "user4"},
+			"alias3": {"user5", "user6"},
+		},
+	}
+
+	var handles []string
+
+	handles = []string{"alias1", "alias2", "user5"}
+	assert.ElementsMatch(t,
+		[]string{"user1", "user2", "user3", "user4", "user5"},
+		config.ExpandHandles(handles),
+	)
+
+	handles = []string{"user9"}
+	assert.ElementsMatch(t,
+		[]string{"user9"},
+		config.ExpandHandles(handles),
+	)
+
+	handles = []string{"alias1", "user1"}
+	assert.ElementsMatch(t,
+		[]string{"user1", "user2"},
+		config.ExpandHandles(handles),
+	)
+}
+
 func TestGetConfigFilePath(t *testing.T) {
 	expectedDir := "/tmp/test-config"
 	t.Setenv("XDG_CONFIG_HOME", expectedDir)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,21 @@ func TestGetDefaultConfig(t *testing.T) {
 	assert.ElementsMatch(t, expectedConfig.Aliases, defaultConfig.Aliases)
 }
 
+func TestAliasExists(t *testing.T) {
+	config := Config{
+		Aliases: map[string][]string{
+			"alias1": {"user1", "user2"},
+			"alias2": {"user3", "user4"},
+			"alias3": {"user5", "user6"},
+		},
+	}
+
+	assert.True(t, config.AliasExists("alias1"))
+	assert.True(t, config.AliasExists("alias2"))
+	assert.True(t, config.AliasExists("alias3"))
+	assert.False(t, config.AliasExists("alias4"))
+}
+
 func TestGetAllAliases(t *testing.T) {
 	config := Config{
 		Aliases: map[string][]string{

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.6.0
 	github.com/mergestat/fluentgraphql v0.0.0-20220506205554-9162f392519f
 	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -17,5 +18,4 @@ require (
 	github.com/graphql-go/graphql v0.8.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/cli/go-gh/v2 v2.4.0 h1:6j3YxA8uJVOL4lBWjqDmMiAQNnJ2fiZagCuEmQXl+pU=
-github.com/cli/go-gh/v2 v2.4.0/go.mod h1:h3salfqqooVpzKmHp6aUdeNx62UmxQRpLbagFSHTJGQ=
-github.com/cli/go-gh/v2 v2.9.0 h1:D3lTjEneMYl54M+WjZ+kRPrR5CEJ5BHS05isBPOV3LI=
-github.com/cli/go-gh/v2 v2.9.0/go.mod h1:MeRoKzXff3ygHu7zP+NVTT+imcHW6p3tpuxHAzRM2xE=
 github.com/cli/go-gh/v2 v2.11.0 h1:TERLYMMWderKBO3lBff/JIu2+eSly2oFRgN2WvO+3eA=
 github.com/cli/go-gh/v2 v2.11.0/go.mod h1:MeRoKzXff3ygHu7zP+NVTT+imcHW6p3tpuxHAzRM2xE=
 github.com/cli/safeexec v1.0.1 h1:e/C79PbXF4yYTN/wauC4tviMxEV13BwljGj0N9j+N00=
@@ -13,9 +9,11 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=
 github.com/deckarep/golang-set/v2 v2.6.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
 github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mergestat/fluentgraphql v0.0.0-20220506205554-9162f392519f h1:q3Sh7LWUDYGus8Al/hZAJLz4MYjQMYORRBbETdcmLlQ=
@@ -27,6 +25,7 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -53,6 +53,16 @@ Usage:
 	}
 }
 
+func cli() error {
+	handles := flag.Args()
+
+	if err := lookupAndPrintForHandles(handles); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // generateQuery accepts an array of usernames and returns a
 // map[string]interface{} suitable for marshalling to JSON for a GraphQL query.
 func generateQuery(usernames []string) map[string]interface{} {
@@ -90,9 +100,8 @@ func missingTokenScopes(scopesHeader string) mapset.Set[string] {
 	return requiredScopes.Difference(tokenScopes)
 }
 
-func cli() error {
-	// Parse handles from command-line arguments and generate a request body
-	handles := flag.Args()
+func lookupAndPrintForHandles(handles []string) error {
+	// generate a request body for the handles
 	body := generateQuery(handles)
 
 	// Marshal the request body to JSON; return and print error if that fails

--- a/main.go
+++ b/main.go
@@ -39,19 +39,6 @@ func (user User) coAuthoredBy() string {
 	return fmt.Sprintf("Co-authored-by: %s <%s>\n", coauthoredName, coauthoredEmail)
 }
 
-// gh pairing-with schustafa
-// gh pairing-with schustafa stephanieg0
-// gh pairing-with --alias buddies schustafa stephanieg0
-// gh pairing-with --alias kiran krhkt
-// gh pairing-with buddies
-// gh pairing-with --alias buddies
-// gh pairing-with --list-aliases
-// gh pairing-with --delete-alias buddies
-
-// LATER:
-// gh pairing-with --start buddies
-// gh pairing-with --stop
-
 func main() {
 	if err := cli(); err != nil {
 		fmt.Fprintf(os.Stderr, "gh-pairing-with failed: %s\n", err.Error())

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/auth"
@@ -41,12 +42,113 @@ type Config struct {
 	Aliases map[string][]string
 }
 
-// func loadConfig() (*Config, error) {
-// 	// look for a config file
-// 	// if it doesn't exist, create a file and return an empty version
+func createConfigFileIfMissing(configFilePath string) error {
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		newConfigFile, err := os.OpenFile(
+			configFilePath,
+			os.O_RDWR|os.O_CREATE|os.O_EXCL,
+			0666,
+		)
+		if err != nil {
+			return err
+		}
 
-// 	// otherwise, return the unmarshaled contents
-// }
+		var emptyConfig Config
+		emptyConfig.Aliases = make(map[string][]string)
+
+		blankConfigFile, err := yaml.Marshal(emptyConfig)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Writer.Write(newConfigFile, blankConfigFile)
+		if err != nil {
+			return err
+		}
+
+		defer newConfigFile.Close()
+		return nil
+	}
+
+	return nil
+}
+
+func getConfigFilePath() (string, error) {
+	const PairingWithDir = "gh-pairing-with"
+	const ConfigYmlFileName = "config.yml"
+	const DEFAULT_XDG_CONFIG_DIRNAME = ".config"
+
+	configDir := os.Getenv("XDG_CONFIG_HOME")
+
+	if configDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		configDir = filepath.Join(homeDir, DEFAULT_XDG_CONFIG_DIRNAME)
+	}
+
+	pairingWithConfigDir := filepath.Join(configDir, PairingWithDir)
+	return filepath.Join(pairingWithConfigDir, ConfigYmlFileName), nil
+}
+
+func loadConfig() (*Config, error) {
+	var config Config
+
+	configFilePath, err := getConfigFilePath()
+
+	if err != nil {
+		return nil, err
+	}
+
+	configDir := filepath.Dir(configFilePath)
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(configDir, os.ModePerm); err != nil {
+			return &config, err
+		}
+	}
+
+	if err := createConfigFileIfMissing(configFilePath); err != nil {
+		return &config, err
+	}
+
+	existingFile, err := os.ReadFile(configFilePath)
+	if err != nil {
+		return &config, err
+	}
+
+	err = yaml.Unmarshal(existingFile, &config)
+	if err != nil {
+		return &config, err
+	}
+
+	return &config, nil
+}
+
+func (c *Config) save() error {
+	configFilePath, err := getConfigFilePath()
+	if err != nil {
+		return err
+	}
+
+	updatedFile, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(configFilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Writer.Write(f, updatedFile)
+	if err != nil {
+		return fmt.Errorf("could not write to config file: %w", err)
+	}
+
+	return nil
+}
 
 // gh pairing-with schustafa
 // gh pairing-with schustafa stephanieg0
@@ -69,7 +171,10 @@ func main() {
 }
 
 func cli() error {
-	// cfg, err := loadConfig()
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
 
 	var aliasFlag string
 	flag.StringVar(&aliasFlag, "alias", "", "alias for a handle or set of handles")
@@ -87,7 +192,7 @@ func cli() error {
 	handles := flag.Args()
 
 	if aliasFlag != "" {
-		if err := storeAliasForHandles(aliasFlag, handles); err != nil {
+		if err := storeAliasForHandles(cfg, aliasFlag, handles); err != nil {
 			return err
 		}
 	} else if err := lookupAndPrintForHandles(handles); err != nil {
@@ -115,45 +220,12 @@ func getAlias(alias string) ([]string, error) {
 	return config.Aliases[alias], nil
 }
 
-func storeAliasForHandles(alias string, handles []string) error {
+func storeAliasForHandles(config *Config, alias string, handles []string) error {
 	fmt.Printf("storing alias %s for handles %v\n", alias, handles)
-
-	var config Config
-
-	existingFile, err := os.ReadFile("config.yml")
-	if err != nil {
-		return fmt.Errorf("could not find file: %w", err)
-	}
-
-	err = yaml.Unmarshal(existingFile, &config)
-	if err != nil {
-		return fmt.Errorf("could not unmarshal yaml: %w", err)
-	}
 
 	config.Aliases[alias] = handles
 
-	// Config := Config{
-	// 	Aliases: map[string][]string{
-	// 		alias: handles,
-	// 	},
-	// }
-
-	updatedFile, err := yaml.Marshal(&config)
-	if err != nil {
-		return fmt.Errorf("could not marshal yaml: %w", err)
-	}
-
-	f, err := os.Create("config.yml")
-	if err != nil {
-		return fmt.Errorf("could not create file: %w", err)
-	}
-
-	defer f.Close()
-
-	_, err = io.Writer.Write(f, updatedFile)
-	if err != nil {
-		return fmt.Errorf("could not write to config file: %w", err)
-	}
+	config.save()
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -66,16 +66,9 @@ func cli() error {
 
 	var aliasFlag string
 	flag.StringVar(&aliasFlag, "alias", "", "alias for a handle or set of handles")
+	listAliasesFlag := flag.Bool("list-aliases", false, "list all aliases")
 
 	flag.Parse()
-
-	if len(flag.Args()) < 1 {
-		fmt.Printf(`
-	Usage:
-	  pairing-with <github_login>...
-`)
-		return nil
-	}
 
 	rawHandles := flag.Args()
 
@@ -84,6 +77,23 @@ func cli() error {
 			return err
 		}
 
+		return nil
+	}
+
+	if *listAliasesFlag {
+		aliases := cfg.GetAllAliases()
+		for alias, handles := range aliases {
+			fmt.Printf("%s: %v\n", alias, strings.Join(handles, " "))
+		}
+
+		return nil
+	}
+
+	if len(rawHandles) < 1 {
+		fmt.Printf(`
+	Usage:
+	  pairing-with <github_login>...
+`)
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func cli() error {
 	handles := flag.Args()
 
 	if aliasFlag != "" {
-		if err := storeAliasForHandles(cfg, aliasFlag, handles); err != nil {
+		if err := cfg.AddAliasForHandles(aliasFlag, handles); err != nil {
 			return err
 		}
 	} else if err := lookupAndPrintForHandles(handles); err != nil {
@@ -97,16 +97,6 @@ func getAlias(alias string) ([]string, error) {
 	}
 
 	return cfg.Aliases[alias], nil
-}
-
-func storeAliasForHandles(config *config.Config, alias string, handles []string) error {
-	fmt.Printf("storing alias %s for handles %v\n", alias, handles)
-
-	config.Aliases[alias] = handles
-
-	config.Save()
-
-	return nil
 }
 
 // generateQuery accepts an array of usernames and returns a

--- a/main.go
+++ b/main.go
@@ -37,16 +37,6 @@ func (user User) coAuthoredBy() string {
 }
 
 func main() {
-	flag.Parse()
-
-	if len(flag.Args()) < 1 {
-		fmt.Printf(`
-Usage:
-  pairing-with <github_login>...
-`)
-		return
-	}
-
 	if err := cli(); err != nil {
 		fmt.Fprintf(os.Stderr, "gh-pairing-with failed: %s\n", err.Error())
 		os.Exit(1)
@@ -54,11 +44,34 @@ Usage:
 }
 
 func cli() error {
+	var aliasFlag string
+	flag.StringVar(&aliasFlag, "alias", "", "alias for a handle or set of handles")
+
+	flag.Parse()
+
+	if len(flag.Args()) < 1 {
+		fmt.Printf(`
+	Usage:
+	  pairing-with <github_login>...
+`)
+		return nil
+	}
+
 	handles := flag.Args()
 
-	if err := lookupAndPrintForHandles(handles); err != nil {
+	if aliasFlag != "" {
+		if err := storeAliasForHandles(aliasFlag, handles); err != nil {
+			return err
+		}
+	} else if err := lookupAndPrintForHandles(handles); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func storeAliasForHandles(alias string, handles []string) error {
+	fmt.Printf("storing alias %s for handles %v\n", alias, handles)
 
 	return nil
 }


### PR DESCRIPTION
Adds support for the following usage:

```
> gh pairing-with --alias buddies user1 user2

> gh pairing-with buddies
Co-authored-by: User1 <user1@example.com>
Co-authored-by: User2 <user2@example.com>
```

Show aliases with:

```
> gh pairing-with --list-aliases
buddies: user1 user2
```

Remove an alias with:

```
gh pairing-with --delete-alias buddies
```

See #11 